### PR TITLE
Remove dependency on forked library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=5.3",
-        "madmatt/saml2": "dev-ss-master",
+        "simplesamlphp/saml2": "dev-master#d701a128d0171b57911e643566b62834b8001a76",
         "robrichards/xmlseclibs": "~1.4.1",
         "whitehat101/apr1-md5": "~1.0"
     },


### PR DESCRIPTION
Merging into ss-master-2 in anticipation of it soon being force-pushed up to ss-master.

See https://github.com/silverstripe/silverstripe-realme/pull/4
